### PR TITLE
Ensure new ingot stack re-renders after placement

### DIFF
--- a/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
+++ b/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
@@ -2,6 +2,7 @@ package fr.iglee42.placeableingots;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -49,6 +50,14 @@ public class IngotBlock extends BaseEntityBlock {
     @Override
     public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
         return new IngotBlockEntity(blockPos,blockState);
+    }
+
+    @Override
+    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        if (blockEntity instanceof IngotBlockEntity ingotBlockEntity) {
+            ingotBlockEntity.markForSync();
+        }
     }
 
     @Override

--- a/src/main/java/fr/iglee42/placeableingots/PlaceableIngots.java
+++ b/src/main/java/fr/iglee42/placeableingots/PlaceableIngots.java
@@ -8,6 +8,7 @@ import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.BlockPos.MutableBlockPos;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -137,6 +138,10 @@ public class PlaceableIngots {
         if (!added) {
             event.getLevel().removeBlock(placementPos, false);
             return false;
+        }
+
+        if (event.getLevel() instanceof ServerLevel serverLevel) {
+            serverLevel.scheduleTick(placementPos, INGOT_BLOCK.get(), 1);
         }
 
         acknowledgeIngotPlacement(event, player);


### PR DESCRIPTION
## Summary
- schedule a server tick when a new ingot stack is placed so the block entity can re-sync after creation
- trigger the block entity to mark for sync during the scheduled tick to force the client to render the first ingot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da5f1e7a688321b03636a3f1774d7b