### PR TITLE
Queue delayed ingot sync to render first placement

### DIFF
--- a/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
+++ b/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
@@ -2,6 +2,7 @@ package fr.iglee42.placeableingots;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
@@ -49,6 +50,14 @@ public class IngotBlock extends BaseEntityBlock {
     @Override
     public @Nullable BlockEntity newBlockEntity(BlockPos blockPos, BlockState blockState) {
         return new IngotBlockEntity(blockPos,blockState);
+    }
+
+    @Override
+    public void tick(BlockState state, ServerLevel level, BlockPos pos, RandomSource random) {
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        if (blockEntity instanceof IngotBlockEntity ingotBlockEntity) {
+            ingotBlockEntity.flushDelayedSync();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- trigger a client-side model data refresh whenever ingot block entity data loads or sync packets arrive
- send a local block update after requesting the refresh so the renderer rebuilds quads once the ingot list is populated
- queue a delayed server tick so the first ingot placement resends its state after block entity data is available on the client

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68da5f1e7a688321b03636a3f1774d7b