### PR TITLE
Delay first ingot sync via block entity ticker

### DIFF
--- a/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
+++ b/src/main/java/fr/iglee42/placeableingots/IngotBlock.java
@@ -1,19 +1,19 @@
 package fr.iglee42.placeableingots;
 
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.BaseEntityBlock;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
@@ -22,7 +22,6 @@ import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
-import net.minecraftforge.common.Tags;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -54,6 +53,22 @@ public class IngotBlock extends BaseEntityBlock {
     @Override
     public RenderShape getRenderShape(BlockState p_49232_) {
         return RenderShape.MODEL;
+    }
+
+    @Nullable
+    @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level level, BlockState state, BlockEntityType<T> type) {
+        if (level.isClientSide()) {
+            return null;
+        }
+
+        if (type == PlaceableIngots.INGOT_BLOCK_ENTITY.get()) {
+            BlockEntityTicker<IngotBlockEntity> ticker = (lvl, pos, blockState, blockEntity) ->
+                    IngotBlockEntity.serverTick(lvl, pos, blockState, blockEntity);
+            return (BlockEntityTicker<T>) ticker;
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- replace the scheduled block tick with a server-side block entity ticker that retries syncing once the first ingot has been added
- reset the delayed sync countdown whenever ingots load or the stack is emptied so the follow-up refresh only fires when needed

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68da5f1e7a688321b03636a3f1774d7b